### PR TITLE
feat: add delete functionality for movies with confirmation prompt

### DIFF
--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from "@/components/AuthProvider";
 import loading from "@/components/ui/loading";
-import { useMovieWithReels } from "@/hooks/useMovies";
+import { useMovieDelete, useMovieWithReels } from "@/hooks/useMovies";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Image from "next/image";
@@ -11,6 +11,7 @@ import { ItemWithIcon } from "@/components/item-with-icon";
 import { Calendar, Clock4, Languages, X } from "lucide-react";
 import SelectForm from "@/components/select-form";
 import { SelectItem } from "@/components/ui/select";
+import { Trash } from "lucide-react";
 
 export default function MovieDetails() {
   const { user, isLoading: isLoadingUser, token } = useAuth();
@@ -18,6 +19,7 @@ export default function MovieDetails() {
   const id = Number(params?.id);
   const [reelId, setReelId] = useState<number | undefined>();
   const [showPreview, setShowPreview] = useState(false);
+  const deleteMutation = useMovieDelete(token);
 
   const { data: movieDetails, isLoading: isLoading } = useMovieWithReels(
     id,
@@ -42,7 +44,31 @@ export default function MovieDetails() {
 
   return (
     <div className="flex flex-col text-white items-center gap-8 mb-12 mx-36">
-      <h1 className="text-3xl font-semibold">{movieDetails.title}</h1>
+      <div className="w-full flex items-center justify-between px-4 md:px-0">
+        <h1 className="text-3xl font-semibold text-center flex-1">
+          {movieDetails.title}
+        </h1>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="hover:bg-red-600 hover:text-white ml-4"
+          onClick={() => {
+            if (!confirm("Are you sure you want to delete this movie?")) return;
+
+            deleteMutation.mutate(id, {
+              onSuccess: () => {
+                router.push("/");
+              },
+              onError: () => {
+                alert("Failed to delete the movie.");
+              },
+            });
+          }}
+        >
+          <Trash className="w-5 h-5" />
+        </Button>
+      </div>
+
       <div className="flex flex-col lg:flex-row items-center gap-24">
         <Image
           src={movieDetails.thumbnail_path}

--- a/src/hooks/useMovies.ts
+++ b/src/hooks/useMovies.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { API_BASE_URL } from "@/config/constants";
 import { MovieWithReels } from "@/types/movie-with-reels";
+import { useMutation } from "@tanstack/react-query";
 
 export function useMovies(sortBy: string, sortDir: string, token?: string) {
   return useQuery({
@@ -32,5 +33,18 @@ export function useMovieWithReels(id: string | number, token?: string) {
     },
     enabled: !!token && !!id,
     retry: false,
+  });
+}
+
+export function useMovieDelete(token?: string) {
+  return useMutation({
+    mutationFn: async (id: string | number) => {
+      const res = await fetch(`${API_BASE_URL}/movies/${id}`, {
+        method: "DELETE",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) throw new Error("Delete failed");
+      return true;
+    },
   });
 }


### PR DESCRIPTION
This pull request introduces functionality for deleting movies directly from the movie details page and adds supporting code for the delete operation. The most important changes include integrating a delete button in the UI, creating a custom hook for the delete operation, and updating imports to accommodate the new functionality.

### UI changes for movie deletion:

* `src/app/movies/[id]/page.tsx`: Added a delete button with a confirmation prompt to the movie details page. The button triggers the `useMovieDelete` hook to delete the movie and redirects to the homepage upon success. ([src/app/movies/[id]/page.tsxL45-R71](diffhunk://#diff-53da5e9b3b26dccdcc75cac3629d440b156deb2d1fec86dbd4374cc68e2ec14bL45-R71))
* `src/app/movies/[id]/page.tsx`: Imported the `Trash` icon from `lucide-react` for the delete button and initialized the `deleteMutation` variable using the `useMovieDelete` hook. ([src/app/movies/[id]/page.tsxR14-R22](diffhunk://#diff-53da5e9b3b26dccdcc75cac3629d440b156deb2d1fec86dbd4374cc68e2ec14bR14-R22))

### Backend integration for movie deletion:

* [`src/hooks/useMovies.ts`](diffhunk://#diff-8936a9c3155392101b1162e4357e751cd7cf4bfdfc1fbfa3e3c1c730486bf2a7R38-R50): Added a new `useMovieDelete` hook that uses `useMutation` to send a DELETE request to the API for movie deletion.
* [`src/hooks/useMovies.ts`](diffhunk://#diff-8936a9c3155392101b1162e4357e751cd7cf4bfdfc1fbfa3e3c1c730486bf2a7R4): Imported `useMutation` from `@tanstack/react-query` to support the new `useMovieDelete` hook.

### Code cleanup:

* `src/app/movies/[id]/page.tsx`: Updated imports to include `useMovieDelete` and removed redundant imports. ([src/app/movies/[id]/page.tsxL5-R5](diffhunk://#diff-53da5e9b3b26dccdcc75cac3629d440b156deb2d1fec86dbd4374cc68e2ec14bL5-R5))