### PR TITLE
refactor: standardize error messages

### DIFF
--- a/src/hooks/useAi.ts
+++ b/src/hooks/useAi.ts
@@ -16,7 +16,7 @@ export function useTextGenerator() {
       target_lang,
       token,
     }: TextGenerator) => {
-      if (!token) throw new Error("Brak tokenu – użytkownik niezalogowany");
+      if (!token) throw new Error("Missing auth token");
       const response = await fetch(`${API_BASE_URL}/reel-texts/`, {
         method: "POST",
         headers: {
@@ -32,7 +32,7 @@ export function useTextGenerator() {
 
       if (!response.ok) {
         const errorMessage =
-          (await response.json())?.detail || "Błąd przy generowaniu tekstu";
+          (await response.json())?.detail || "Failed to generate text";
         throw new Error(errorMessage);
       }
 

--- a/src/hooks/useCreateAudio.ts
+++ b/src/hooks/useCreateAudio.ts
@@ -11,7 +11,7 @@ export function useCreateAudio() {
   return useMutation({
     mutationFn: async ({ reel, token }: CreateAudioArgs) => {
       const { title, subtitlesText, voice, audioLang, speed } = reel;
-      if (!token) throw new Error("Brak tokenu – użytkownik niezalogowany");
+      if (!token) throw new Error("Missing auth token");
       const body = JSON.stringify({
         title,
         text: subtitlesText,
@@ -19,7 +19,6 @@ export function useCreateAudio() {
         language: audioLang,
         speed,
       });
-      console.log("Creating audio with body:", body);
       const response = await fetch(`${API_BASE_URL}/audios/`, {
         method: "POST",
         headers: {
@@ -31,13 +30,11 @@ export function useCreateAudio() {
 
       if (!response.ok) {
         const errorMessage =
-          (await response.json())?.detail || "Błąd przy tworzeniu audio";
+          (await response.json())?.detail || "Error creating audio";
         throw new Error(errorMessage);
       }
 
-      const audioData = await response.json();
-      console.log(`audio id : ${audioData.id}`);
-      return audioData;
+      return await response.json();
     },
   });
 }
@@ -45,12 +42,11 @@ export function useCreateAudio() {
 export function useCreateAudioTranscription() {
   return useMutation({
     mutationFn: async ({ audioId, transcriptionModel, token }) => {
-      if (!token) throw new Error("Brak tokenu – użytkownik niezalogowany");
+      if (!token) throw new Error("Missing auth token");
       const body = JSON.stringify({
         audio_id: audioId,
         transcription_model: transcriptionModel,
       });
-      console.log("Creating audio transcript with body:", body);
       const response = await fetch(`${API_BASE_URL}/audios/transcribe`, {
         method: "POST",
         headers: {
@@ -63,7 +59,7 @@ export function useCreateAudioTranscription() {
       if (!response.ok) {
         const errorMessage =
           (await response.json())?.detail ||
-          "Błąd przy tworzeniu transkrypcji audio";
+          "Error creating audio transcription";
         throw new Error(errorMessage);
       }
 

--- a/src/hooks/useCreateMovie.ts
+++ b/src/hooks/useCreateMovie.ts
@@ -10,13 +10,8 @@ type CreateMovieArgs = {
 export function useCreateMovies() {
   return useMutation({
     mutationFn: async ({ reel, token }: CreateMovieArgs) => {
-      console.log("reel:", reel);
       const { title, description, nativeLang, videoFile } = reel;
-
-      console.log("token:", token);
-      console.log("reel:", reel);
-
-      if (!token) throw new Error("Brak tokenu – użytkownik niezalogowany");
+      if (!token) throw new Error("Missing auth token");
 
       const formData = new FormData();
       formData.append("title", title);
@@ -34,7 +29,7 @@ export function useCreateMovies() {
 
       if (!movieRes.ok) {
         const errorMessage =
-          (await movieRes.json())?.detail || "Błąd przy tworzeniu filmu";
+          (await movieRes.json())?.detail || "Error creating movie";
         throw new Error(errorMessage);
       }
 

--- a/src/hooks/useCreateMusic.ts
+++ b/src/hooks/useCreateMusic.ts
@@ -11,7 +11,7 @@ export function useCreateMusic() {
   return useMutation({
     mutationFn: async ({ reel, token }: CreateMusicArgs) => {
       const { musicTitle, musicFile } = reel;
-      if (!token) throw new Error("Brak tokenu – użytkownik niezalogowany");
+      if (!token) throw new Error("Missing auth token");
 
       const formData = new FormData();
       formData.append("title", musicTitle);
@@ -27,7 +27,7 @@ export function useCreateMusic() {
 
       if (!musicRes.ok) {
         const errorMessage =
-          (await musicRes.json())?.detail || "Błąd przy tworzeniu muzyki";
+          (await musicRes.json())?.detail || "Error creating music";
         throw new Error(errorMessage);
       }
 

--- a/src/hooks/useCreateReel.ts
+++ b/src/hooks/useCreateReel.ts
@@ -11,7 +11,7 @@ export function useCreateReels() {
       includeSrt,
       token,
     }) => {
-      if (!token) throw new Error("Brak tokenu – użytkownik niezalogowany");
+      if (!token) throw new Error("Missing auth token");
       const response = await fetch(`${API_BASE_URL}/reels/`, {
         method: "POST",
         headers: {
@@ -29,7 +29,7 @@ export function useCreateReels() {
 
       if (!response.ok) {
         const errorMessage =
-          (await response.json())?.detail || "Błąd przy tworzeniu rolki";
+          (await response.json())?.detail || "Error creating reel";
         throw new Error(errorMessage);
       }
 

--- a/src/hooks/useGetMovie.ts
+++ b/src/hooks/useGetMovie.ts
@@ -8,7 +8,7 @@ export function useMovies(movieId: number, token?: string) {
           headers: token ? { Authorization: `Bearer ${token}` } : {},
         },
       );
-      if (!res.ok) throw new Error("Not authenticated");
+      if (!res.ok) throw new Error("Error fetching movies");
       return res.json();
     },
     enabled: !!token,
@@ -23,7 +23,7 @@ export function useMovieWithReels(id: string | number, token?: string) {
       const res = await fetch(`${API_BASE_URL}/movies/${id}`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
-      if (!res.ok) throw new Error("Not authenticated");
+      if (!res.ok) throw new Error("Error fetching movie with reels");
       return res.json();
     },
     enabled: !!token && !!id,


### PR DESCRIPTION
This pull request focuses on improving error messages across multiple hooks in the codebase, ensuring they are more consistent and user-friendly. The changes replace Polish error messages with English equivalents and remove unnecessary `console.log` statements for cleaner code.

### Error Message Improvements:
* [`src/hooks/useAi.ts`](diffhunk://#diff-6851b046d43bc566802f0c71e0310c779e3426ce462f478f7f40f7cebc8a0039L19-R19): Updated error messages in `useTextGenerator` to replace Polish text with English equivalents, such as "Missing auth token" and "Failed to generate text." [[1]](diffhunk://#diff-6851b046d43bc566802f0c71e0310c779e3426ce462f478f7f40f7cebc8a0039L19-R19) [[2]](diffhunk://#diff-6851b046d43bc566802f0c71e0310c779e3426ce462f478f7f40f7cebc8a0039L35-R35)
* [`src/hooks/useCreateAudio.ts`](diffhunk://#diff-1b6eb3b61f967adf46a85b29535ab04e6731d0cf8047731f951a0d9a7648e5adL14-L22): Improved error messages in `useCreateAudio` and `useCreateAudioTranscription` with English text, such as "Error creating audio" and "Error creating audio transcription." [[1]](diffhunk://#diff-1b6eb3b61f967adf46a85b29535ab04e6731d0cf8047731f951a0d9a7648e5adL14-L22) [[2]](diffhunk://#diff-1b6eb3b61f967adf46a85b29535ab04e6731d0cf8047731f951a0d9a7648e5adL34-L53) [[3]](diffhunk://#diff-1b6eb3b61f967adf46a85b29535ab04e6731d0cf8047731f951a0d9a7648e5adL66-R62)
* [`src/hooks/useCreateMovie.ts`](diffhunk://#diff-55b677c638f4a196e7a79bb7d2e214db997ed5fa70d0683e213e52f1145d7fa1L13-R14): Updated error messages in `useCreateMovies` to English, such as "Error creating movie." [[1]](diffhunk://#diff-55b677c638f4a196e7a79bb7d2e214db997ed5fa70d0683e213e52f1145d7fa1L13-R14) [[2]](diffhunk://#diff-55b677c638f4a196e7a79bb7d2e214db997ed5fa70d0683e213e52f1145d7fa1L37-R32)
* [`src/hooks/useCreateMusic.ts`](diffhunk://#diff-97bfcc8e7b686b5bb6ccc4288591e144e11f965e0675648d544e9253733d6540L14-R14): Replaced Polish error messages in `useCreateMusic` with English equivalents, such as "Error creating music." [[1]](diffhunk://#diff-97bfcc8e7b686b5bb6ccc4288591e144e11f965e0675648d544e9253733d6540L14-R14) [[2]](diffhunk://#diff-97bfcc8e7b686b5bb6ccc4288591e144e11f965e0675648d544e9253733d6540L30-R30)
* [`src/hooks/useCreateReel.ts`](diffhunk://#diff-65cf29e43626954101c2ec19ed4af0979b05f5cc0ee0e32c13b6056b5ef6a272L14-R14): Improved error messages in `useCreateReels` with English text, such as "Error creating reel." [[1]](diffhunk://#diff-65cf29e43626954101c2ec19ed4af0979b05f5cc0ee0e32c13b6056b5ef6a272L14-R14) [[2]](diffhunk://#diff-65cf29e43626954101c2ec19ed4af0979b05f5cc0ee0e32c13b6056b5ef6a272L32-R32)
* [`src/hooks/useGetMovie.ts`](diffhunk://#diff-2d5d7b4e4bfba705e5817c770f66c1592ea176e51fd715e1499a5cce5a00221cL11-R11): Updated error messages in `useMovies` and `useMovieWithReels` to provide clearer English descriptions, such as "Error fetching movies" and "Error fetching movie with reels." [[1]](diffhunk://#diff-2d5d7b4e4bfba705e5817c770f66c1592ea176e51fd715e1499a5cce5a00221cL11-R11) [[2]](diffhunk://#diff-2d5d7b4e4bfba705e5817c770f66c1592ea176e51fd715e1499a5cce5a00221cL26-R26)

### Code Cleanup:
* Removed `console.log` statements across multiple hooks (`useCreateAudio`, `useCreateMovies`, `useCreateAudioTranscription`) to simplify the codebase and reduce unnecessary logging. [[1]](diffhunk://#diff-1b6eb3b61f967adf46a85b29535ab04e6731d0cf8047731f951a0d9a7648e5adL14-L22) [[2]](diffhunk://#diff-55b677c638f4a196e7a79bb7d2e214db997ed5fa70d0683e213e52f1145d7fa1L13-R14) [[3]](diffhunk://#diff-1b6eb3b61f967adf46a85b29535ab04e6731d0cf8047731f951a0d9a7648e5adL66-R62)